### PR TITLE
feat(img): CSS Backgrounds for non-IMG tags

### DIFF
--- a/src/img/docs/demo.html
+++ b/src/img/docs/demo.html
@@ -8,6 +8,13 @@
   </ul>
   <hr />
   <div>
+    <h3>It Can Also Do a CSS Background</h3>
+    <div ph-img="550x100" style="width: 550px; height: 100px; background-repeat: no-repeat;">
+      <h4>Oooh...</h4>
+    </div>
+  </div>
+  <hr />
+  <div>
     <h3>It's More Powerful with Bootstrap!</h3>
     <ul class="inline">
       <li>

--- a/src/img/docs/readme.md
+++ b/src/img/docs/readme.md
@@ -1,6 +1,8 @@
 The `phImg` directive creates client-side placeholder images in any
 size. The directive creates a PNG image using the HTML5 canvas library and
-uses the generated client-side URL as the `src` on an `img` element.
+uses the generated client-side URL as either (a) the `src` attribute, if the
+element is an `img`, or (b) the `css-background` for all other types of
+elements.
 
 The directive takes a single eponymous attribute that specifies the dimensions
 of the image to create; the expected format is "100x100".

--- a/src/img/img.js
+++ b/src/img/img.js
@@ -51,7 +51,8 @@ angular.module( 'placeholders.img', [] )
        * then redraw the image.
        */
       scope.$watch('dimensions', function () {
-        var matches = scope.dimensions.match( /^(\d+)x(\d+)$/ );
+        var matches = scope.dimensions.match( /^(\d+)x(\d+)$/ ),
+            dataUrl;
         
         if(  ! matches ) {
           console.error("Expected '000x000'. Got " + scope.dimensions);
@@ -65,8 +66,16 @@ angular.module( 'placeholders.img', [] )
         element.prop( "title", scope.dimensions );
         element.prop( "alt", scope.dimensions );
 
-        // And draw the image, setting the returned data URL as the image src.
-        element.prop( 'src', drawImage() );
+        // And draw the image, getting the returned data URL.
+        dataUrl = drawImage();
+
+        // If this is an `img` tag, set the src as the data URL. Else, we set
+        // the CSS `background-image` property to same.
+        if ( element.prop( "tagName" ) === "IMG" ) {
+          element.prop( 'src', dataUrl );
+        } else {
+          element.css( 'background-image', 'url("' + dataUrl + '")' );      
+        }
       });
 
       /**

--- a/src/img/test/imgSpec.js
+++ b/src/img/test/imgSpec.js
@@ -30,5 +30,13 @@ describe( 'phImg', function () {
     expect( element.prop( 'alt' ) ).toBe( dimensions );
     expect( element.prop( 'title' ) ).toBe( dimensions );
   }));
+
+  it( 'should set the CSS `background-image` property if tag is not an img', inject( function () {
+    element = $compile( '<div ph-img="{{w}}x{{h}}"></div>' )( scope );
+    scope.$digest();
+
+    var bgImg = element.css( 'background-image' );
+    expect( bgImg.length ).toBeGreaterThan( 0 );
+  }));
 });
 


### PR DESCRIPTION
The phImg directive will now set the `src` attribute only for `img`
tags. For all other tags, it will set the CSS `background-image`
property to `URL(dataURL)`.

Closes #5.
