### PR TITLE
feat(txt): shortened and combined attributes

### DIFF
--- a/src/txt/docs/demo.html
+++ b/src/txt/docs/demo.html
@@ -1,9 +1,13 @@
 <div ng-controller="TextDemoCtrl">
   <h3>Here's a few sentences</h3>
   <p># Sentences: <input ng-model="numSentences" /></p>
-  <p ph-txt num-sentences="{{numSentences}}"></p>
+  <p ph-txt="{{numSentences}}s"></p>
 
   <h3>And a few paragraphs</h3>
   <p># Paragraphs: <input ng-model="numParagraphs" /></p>
-  <div ph-txt num-paragraphs="{{numParagraphs}}"></div>
+  <div ph-txt="{{numParagraphs}}p"></div>
+
+  <h3>And combining both:</h3>
+  <p># Paragraphs: <input ng-model="numCombined" /></p>
+  <div ph-txt="{{numCombined}}"></div>
 </div>

--- a/src/txt/docs/demo.js
+++ b/src/txt/docs/demo.js
@@ -1,4 +1,5 @@
 var TextDemoCtrl = function ( $scope ) {
   $scope.numSentences = "3";
   $scope.numParagraphs = "2";
+  $scope.numCombined = "2p3s";
 };

--- a/src/txt/docs/readme.md
+++ b/src/txt/docs/readme.md
@@ -1,10 +1,16 @@
 The `phTxt` directive dynamically inserts "Lorem ipsum"-style text
 into an element. It can work as either an element or an attribute. 
 
-`phTxt` accepts two optional attributes: `num-sentences` and
-`num-paragraphs`. If `num-sentences` is provided, the body of the element will
-be replaced with the specified number of sentences. `num-paragraphs` will
-replace the body of the element with the specified number of `<p>` tags
-containing random sentences. 
+`phTxt` accepts a single value that can express the number of desired paragraphs
+and/or sentences. The format is `#p#s`, where the numbers represent the number
+of requested paragraphs and sentences, respectively. Order is irrelevant.
 
-The default behavior is a random number of paragraphs.
+If both are provided, the element will contain the requested number of
+paragraphs, each with the requested number of sentences.
+
+If just the number of paragraphs is provided, the number of sentences will be
+random for each paragraph. If just the number of sentences is provided, no
+paragraphs will be generated - just the specified number of sentences.
+
+If neither are provided, the default behavior is a random number of paragraphs,
+each with a random number of sentences.

--- a/src/txt/test/txtSpec.js
+++ b/src/txt/test/txtSpec.js
@@ -85,7 +85,7 @@ describe( 'phTxt Directive', function () {
 
   it( 'should add a specified number of paragraphs', function () {
 
-    var tpl =  '<div ph-txt num-paragraphs="{{numParagraphs}}"></div>',
+    var tpl =  '<div ph-txt="{{numParagraphs}}p"></div>',
         element = $compile( tpl )( scope ),
         paragraphCount;
 
@@ -99,7 +99,7 @@ describe( 'phTxt Directive', function () {
 
   it( 'should add the specified number of sentences', function () {
     
-    var tpl =  '<div ph-txt num-sentences="{{numSentences}}"></div>',
+    var tpl =  '<div ph-txt="{{numSentences}}s"></div>',
         element = $compile( tpl )( scope ),
         text;
     
@@ -113,6 +113,31 @@ describe( 'phTxt Directive', function () {
     // *less* than the length after the split because 5 periods makes 6
     // segments.
     expect( text.split('.').length - 1 ).toBe( scope.numSentences );
+  });
+
+  it( 'should add the specified number of sentences in the specified # of paragraphs', function () {
+    
+    var tpl =  '<div ph-txt="{{numParagraphs}}p{{numSentences}}s"></div>',
+        element = $compile( tpl )( scope ),
+        paragraphs;
+    
+    scope.numSentences = 5;
+    scope.numParagraphs = 3;
+    scope.$digest();
+
+
+    paragraphs = element.find('p');
+    expect( paragraphs.length ).toBe( scope.numParagraphs );
+    
+    angular.forEach( paragraphs, function ( p ) {
+      // Get the inner text of the element.
+      var text = angular.element( p ).text();
+    
+      // It should have the specified number of sentences. We have to take one
+      // *less* than the length after the split because 5 periods makes 6
+      // segments.
+      expect( text.split('.').length - 1 ).toBe( scope.numSentences );
+    });
   });
 
 });


### PR DESCRIPTION
The numSentences and numParagraphs attributes have been abolished in
favor of the simpler `#p#s` format provided to the phTxt attribute
directly. This has the added value that the number of sentences per
paragraph can now be customized.

Closes #4.
